### PR TITLE
Version 0.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ with open("README.md", "r") as fh:
 
 setup(name='tlspyo',
       packages=[package for package in find_packages()],
-      version='0.2.5',
-      download_url='https://github.com/MISTLab/tls-python-object/archive/refs/tags/v0.2.5.tar.gz',
+      version='0.2.6',
+      download_url='https://github.com/MISTLab/tls-python-object/archive/refs/tags/v0.2.6.tar.gz',
       license='MIT',
       description='Secure transport of python objects using TLS encryption',
       long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 from setuptools import setup, find_packages
 import sys
 
-from pathlib import Path
-
 
 if sys.version_info < (3, 7):
     sys.exit('Sorry, Python < 3.7 is not supported, upgrade your python installation to use tlspyo.')
@@ -14,8 +12,8 @@ with open("README.md", "r") as fh:
 
 setup(name='tlspyo',
       packages=[package for package in find_packages()],
-      version='0.2.6',
-      download_url='https://github.com/MISTLab/tls-python-object/archive/refs/tags/v0.2.6.tar.gz',
+      version='0.3.0',
+      download_url='https://github.com/MISTLab/tls-python-object/archive/refs/tags/v0.3.0.tar.gz',
       license='MIT',
       description='Secure transport of python objects using TLS encryption',
       long_description=long_description,
@@ -26,7 +24,7 @@ setup(name='tlspyo',
       install_requires=[
         'twisted',
         'pyOpenSSL>22.1.0',
-        'service_identity==21.1.0',
+        'service_identity',
         'platformdirs'
         ],
       extras_requires={

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name='tlspyo',
       install_requires=[
         'twisted',
         'pyOpenSSL>22.1.0',
-        'service_identity',
+        'service_identity==21.1.0',
         'platformdirs'
         ],
       extras_requires={

--- a/tlspyo/api.py
+++ b/tlspyo/api.py
@@ -68,7 +68,6 @@ class Relay:
 
         assert accepted_groups is None or isinstance(accepted_groups, dict), "Invalid format for accepted_groups."
 
-        self._stopped = False
         self._header_size = header_size
         self._local_com_port = local_com_port
         self._local_com_srv = socket(AF_INET, SOCK_STREAM)
@@ -95,6 +94,8 @@ class Relay:
         self._send_local('TEST')
 
         self._finalizer = weakref.finalize(self, self._finalize)
+        self._stop_lock = Lock()
+        self._stopped = False
 
     def _finalize(self):
         self.stop()
@@ -109,16 +110,18 @@ class Relay:
         Stop the Relay.
         """
         try:
-            if not self._stopped:
-                self._send_local('STOP')
+            with self._stop_lock:
+                if not self._stopped:
+                    self._send_local('STOP')
 
-                self._p.join()
-                self._local_com_conn.close()
-                self._local_com_srv.close()
-                self._local_com_addr = None
-                self._stopped = True
-        except KeyboardInterrupt:
+                    self._p.join()
+                    self._local_com_conn.close()
+                    self._local_com_srv.close()
+                    self._local_com_addr = None
+                    self._stopped = True
+        except KeyboardInterrupt as e:
             self.stop()
+            raise e
 
 
 class Endpoint:
@@ -178,8 +181,6 @@ class Endpoint:
         elif security == "SSL":
             security = "TLS"
 
-        self._stopped = False
-
         # threading for local object receiving
         self.__obj_buffer = queue.Queue()
         self.__socket_closed_lock = Lock() 
@@ -228,6 +229,8 @@ class Endpoint:
         self._t_manage_received_objects.start()
 
         self._finalizer = weakref.finalize(self, self._finalize)
+        self._stop_lock = Lock()
+        self._stopped = False
 
     def _finalize(self):
         self.stop()
@@ -368,24 +371,26 @@ class Endpoint:
         Stop the Endpoint.
         """
         try:
-            if not self._stopped:
-                # send STOP to the local server
-                self._send_local(cmd='STOP', dest=None, obj=None)
+            with self._stop_lock:
+                if not self._stopped:
+                    # send STOP to the local server
+                    self._send_local(cmd='STOP', dest=None, obj=None)
 
-                # Join the message reading thread
-                with self.__socket_closed_lock:
-                    self.__socket_closed_flag = True
-                self._t_manage_received_objects.join()
+                    # Join the message reading thread
+                    with self.__socket_closed_lock:
+                        self.__socket_closed_flag = True
+                    self._t_manage_received_objects.join()
 
-                # join Twisted process and stop local server
-                self._p.join()
+                    # join Twisted process and stop local server
+                    self._p.join()
 
-                self._local_com_conn.close()
-                self._local_com_srv.close()
-                self._local_com_addr = None
-                self._stopped = True
-        except KeyboardInterrupt:
+                    self._local_com_conn.close()
+                    self._local_com_srv.close()
+                    self._local_com_addr = None
+                    self._stopped = True
+        except KeyboardInterrupt as e:
             self.stop()
+            raise e
 
     def _process_received_list(self, received_list):
         if self._deserialize_locally:

--- a/tlspyo/client.py
+++ b/tlspyo/client.py
@@ -49,7 +49,7 @@ class ClientProtocol(Protocol):
                 stamp, cmd, obj = self._client.deserializer(self._buffer[i:j])
                 if cmd == 'ACK':
                     try:
-                        logger.info(f"ACK received after {time.monotonic() - self._client.pending_acks[stamp][0]}s.")
+                        logger.debug(f"ACK received after {time.monotonic() - self._client.pending_acks[stamp][0]}s.")
                         del self._client.pending_acks[stamp]  # delete pending ACK
                     except KeyError:
                         logger.warning(f"Received ACK for stamp {stamp} not present in pending ACKs.")

--- a/tlspyo/utils.py
+++ b/tlspyo/utils.py
@@ -1,11 +1,11 @@
-import signal
+# import signal
 import queue
 
 
-try:
-    signal.signal(signal.SIGINT, signal.SIG_DFL)
-except Exception as e:
-    pass
+# try:
+#     signal.signal(signal.SIGINT, signal.SIG_DFL)
+# except Exception as e:
+#     pass
 
 
 def wait_event(event):


### PR DESCRIPTION
This version adds support for the SubjectAltName extension of TLS certificates, required by the new version of `service-identity`.

It also removes a "hack" that was causing issues with KeyboardInterrupt on newer versions of Windows.